### PR TITLE
Change repo to buildawesome, modify checksum

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -13,10 +13,10 @@ maintainers = ["eric_G"]
 license = "MIT"
 website = "https://www.11ty.dev/"
 admindoc = "https://www.11ty.dev/docs/"
-code = "https://github.com/11ty/eleventy/"
+code = "https://github.com/11ty/buildawesome"
 
 [integration]
-yunohost = ">= 12.1.38"
+yunohost = ">= 12.1.39"
 helpers_version = "2.1"
 architectures = "all"
 multi_instance = true
@@ -61,5 +61,5 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.nodejs]
-    version = "22"
+    version = "24"
     

--- a/manifest.toml
+++ b/manifest.toml
@@ -45,8 +45,8 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/11ty/eleventy/archive/refs/tags/v3.1.6.tar.gz"
-        sha256 = "e065fba4ed927f27bc5c426557696031dba14ea4f825043375c19101c1d50ed3"
+        url = "https://github.com/11ty/buildawesome/archive/refs/tags/v3.1.6.tar.gz"
+        sha256 = "cbd91def5a0b1fdc7118c60ca9b20db80a49a2eb3c298ef55088182856e622e9"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- 11ty changed the name of their repo to `buildawesome`, and the checksum of the release tgz also changed.

## Solution

- modify the URL and checksum in `manifest.toml`

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)
